### PR TITLE
Fix crash caused by incorrect output path format

### DIFF
--- a/ios/Classes/HeifConverterPlugin.swift
+++ b/ios/Classes/HeifConverterPlugin.swift
@@ -23,7 +23,7 @@ public class HeifConverterPlugin: NSObject, FlutterPlugin {
       }
       if(output == nil || output!.isEmpty){
         if(format != nil && !format!.isEmpty){
-          output = NSTemporaryDirectory().appendingFormat("%d.%s", Date().timeIntervalSince1970 * 1000, format!)
+          output = NSTemporaryDirectory().appendingFormat("%lf%@", Date().timeIntervalSince1970 * 1000, format!)
         } else {
           result(FlutterError(code: "illegalArgument", message: "Output path and format is blank.", details: nil))
           break


### PR DESCRIPTION
Exception:

> String(format:locale:arguments:): Provided argument types ["Swift.Double", "Swift.String"] (with inferred specifiers ["%lf", "%@"]) do not match the format string's specifiers [Error Domain=NSCocoaErrorDomain Code=2048 "Format '%d.%s' does not match expected '%lf%@'" UserInfo={NSDebugDescription=Format '%d.%s' does not match expected '%lf%@'}]