### PR TITLE
fix: use kebab-case product name in Package.swift for Flutter SPM compatibility

### DIFF
--- a/ios/heif_converter/Package.swift
+++ b/ios/heif_converter/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .iOS("12.0"),
     ],
     products: [
-        .library(name: "heif_converter", targets: ["heif_converter"]),
+        .library(name: "heif-converter", targets: ["heif_converter"]),
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
## Problem

Flutter's generated `FlutterGeneratedPluginSwiftPackage/Package.swift` references plugin products using **kebab-case**, following the SPM convention (underscores → dashes). The current product name `heif_converter` (with underscores) causes a build error when integrating via SPM:

```
product 'heif-converter' required by package 'fluttergeneratedpluginswiftpackage'
target 'FlutterGeneratedPluginSwiftPackage' not found in package 'heif_converter'.
```

## Fix

Rename the SPM library product from `heif_converter` to `heif-converter` in `ios/heif_converter/Package.swift`.

The target name (`heif_converter`) is unchanged — only the **product name** is updated to match the kebab-case name Flutter expects.

## How to verify

After applying this fix, a Flutter project using `heif_converter` via SPM should build without the above error.